### PR TITLE
fix fatal error for php 7

### DIFF
--- a/src/GitElephant/Objects/Commit.php
+++ b/src/GitElephant/Objects/Commit.php
@@ -221,7 +221,7 @@ class Commit implements TreeishInterface, \Countable
      */
     private function parseOutputLines($outputLines)
     {
-        $message = '';
+        $message = array();
         foreach ($outputLines as $line) {
             $matches = array();
             if (preg_match('/^commit (\w+)$/', $line, $matches) > 0) {


### PR DESCRIPTION
running this project on php 7 gives "fatal Error: [] operator not supported for strings" error  - this commit will fix it